### PR TITLE
Fix for "undefined" random port

### DIFF
--- a/server.js
+++ b/server.js
@@ -109,6 +109,6 @@ function updateID(id, name) {
     clients.push({name:id, id:name});
 }
 
-http.listen(process.env.PORT, function(){
-    console.log('listening on *:'+process.env.PORT);
+http.listen(process.env.PORT || 8080, function(){
+    console.log('listening on *:' + (process.env.PORT || 8080));
 });


### PR DESCRIPTION
Added an or-statement to the `http.listen` statement to give a defined port.